### PR TITLE
Fix uom typo in rocketarium

### DIFF
--- a/orc/ROCKETARIUM.ORC
+++ b/orc/ROCKETARIUM.ORC
@@ -344,7 +344,7 @@ Using this file:
 			<Density>344.3</Density>
 			<Type>BULK</Type>
 		</Material>
-		<Material UnitsOfMeasure="kg/m3f">
+		<Material UnitsOfMeasure="kg/m3">
 			<Name>Plywood, aircraft, 3/16 in. bulk</Name>
 			<Density>344.3</Density>
 			<Type>BULK</Type>

--- a/orc/generic_materials.orc
+++ b/orc/generic_materials.orc
@@ -755,7 +755,7 @@ attributes.  This seems to have no effect; looks like everything is actually kg/
             <Density>0.00402</Density>
             <Type>LINE</Type>
         </Material>
-        <Material UnitsOfMeasure="kkg/m3">
+        <Material UnitsOfMeasure="kg/m3">
             <Name>Elastic, flat, 3/8 in. width</Name>
             <Density>0.006087</Density>
             <Type>BULK</Type>


### PR DESCRIPTION
Found another issue in the rocketarium uom: once instance that had `kg/m3f` instead of `kg/m3`.